### PR TITLE
[transports/websocket/hybi-16] fix frame parsing for dataLength 65536

### DIFF
--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -227,7 +227,7 @@ WebSocket.prototype.frame = function (opcode, str) {
     , dataLength = dataBuffer.length
     , startOffset = 2
     , secondByte = dataLength;
-  if (dataLength > 65536) {
+  if (dataLength > 65535) {
     startOffset = 10;
     secondByte = 127;
   }


### PR DESCRIPTION
Import from https://github.com/overleaf/real-time/pull/62

For https://github.com/overleaf/issues/issues/2017
For https://github.com/overleaf/issues/issues/3245

I omitted the `console.log` statement as it's a blocking operation.