### PR TITLE
[transports/flashsocket] fix EventEmitter usage in policyfile dependency

### DIFF
--- a/lib/transports/flashsocket.js
+++ b/lib/transports/flashsocket.js
@@ -4,6 +4,26 @@
  * MIT Licensed
  */
 
+// EventEmitter has been removed from process in node >= 7
+// https://github.com/nodejs/node/commit/62b544290a075fe38e233887a06c408ba25a1c71
+/*
+  The dependency 'policyfile' expects the EventEmitter to be available at
+    `process.EventEmitter`.
+  See this trace:
+  ---
+
+  /app/node_modules/policyfile/lib/server.js:254
+  Object.keys(process.EventEmitter.prototype).forEach(function proxy (key){
+                                   ^
+
+  TypeError: Cannot read property 'prototype' of undefined
+    at Object.<anonymous> (/app/node_modules/policyfile/lib/server.js:254:34)
+ */
+if (process.versions.node.split('.')[0] >= 7) {
+  // eslint-disable-next-line node/no-deprecated-api
+  process.EventEmitter = require('events')
+}
+
 /**
  * Module requirements.
  */


### PR DESCRIPTION
Import from https://github.com/overleaf/real-time/pull/66

