### PR TITLE
prevent exception in client.transport getter

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+0.9.19-overleaf-5 / 2021-05-19
+==============================
+
+ * Overleaf: prevent exception in client.transport getter
+
 0.9.19-overleaf-4 / 2020-07-30
 ==============================
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -71,7 +71,7 @@ Socket.prototype.__defineGetter__('handshake', function () {
  */
 
 Socket.prototype.__defineGetter__('transport', function () {
-  return this.manager.transports[this.id].name;
+  return this.manager.transports[this.id] && this.manager.transports[this.id].name;
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "socket.io"
-  , "version": "0.9.19-overleaf-4"
+  , "version": "0.9.19-overleaf-5"
   , "description": "Real-time apps made cross-browser & easy with a WebSocket-like API"
   , "homepage": "http://socket.io"
   , "keywords": ["websocket", "socket", "realtime", "socket.io", "comet", "ajax"]


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

`this.manager.transports[this.id]` can be undefined,  so the `client.transport` getter triggers an exception `Uncaught TypeError: Cannot read property 'name' of undefined`

### New behaviour

The getter now returns undefined when `this.manager.transports[this.id]` is undefined.

### Other information (e.g. related issues)


Found in https://github.com/overleaf/real-time/pull/217