### PR TITLE
Only convert the current message to a string once the last fragment has been received

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+0.9.19-overleaf-6 / 2022-08-18
+==============================
+
+* Overleaf: only convert the current message to a string once the last fragment has been received
+
 0.9.19-overleaf-5 / 2021-05-19
 ==============================
 

--- a/lib/transports/websocket/hybi-16.js
+++ b/lib/transports/websocket/hybi-16.js
@@ -281,7 +281,7 @@ function Parser (opts) {
   this.expectOffset = 0;
   this.expectBuffer = null;
   this.expectHandler = null;
-  this.currentMessage = '';
+  this.currentMessage = [];
   this._maxBuffer = (opts && opts.maxBuffer) || 10E7;
   this._dataLength = 0;
 
@@ -290,10 +290,10 @@ function Parser (opts) {
     // text
     '1': function(data) {
       var finish = function(mask, data) {
-        self.currentMessage += self.unmask(mask, data);
+        self.currentMessage.push(self.unmask(mask, data, true));
         if (self.state.lastFragment) {
-          self.emit('data', self.currentMessage);
-          self.currentMessage = '';
+          self.emit('data', self.concatBuffers(self.currentMessage).toString('utf8'));
+          self.currentMessage = [];
         }
         self.endPacket();
       }
@@ -338,11 +338,10 @@ function Parser (opts) {
     // binary
     '2': function(data) {
       var finish = function(mask, data) {
-        if (typeof self.currentMessage == 'string') self.currentMessage = []; // build a buffer list
         self.currentMessage.push(self.unmask(mask, data, true));
         if (self.state.lastFragment) {
           self.emit('binary', self.concatBuffers(self.currentMessage));
-          self.currentMessage = '';
+          self.currentMessage = [];
         }
         self.endPacket();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "socket.io"
-  , "version": "0.9.19-overleaf-5"
+  , "version": "0.9.19-overleaf-6"
   , "description": "Real-time apps made cross-browser & easy with a WebSocket-like API"
   , "homepage": "http://socket.io"
   , "keywords": ["websocket", "socket", "realtime", "socket.io", "comet", "ajax"]


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour

When a long message is sent as several frames (observed in Chrome v99, but not in Firefox v97), if the frame boundary occurs in the middle of a multibyte character then the combined message will be corrupted by the addition of an extra character at the point where the frames were concatenated with `+=` into a single string.

### New behaviour

By building up the current message as parts of a buffer, and only combining them once all the data has been received, the final UTF-8 string is no longer corrupted.

