### PR TITLE
upgrade socket.io-client to include fixes for npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "socket.io"
-  , "version": "0.9.19-overleaf-6"
+  , "version": "0.9.19-overleaf-7"
   , "description": "Real-time apps made cross-browser & easy with a WebSocket-like API"
   , "homepage": "http://socket.io"
   , "keywords": ["websocket", "socket", "realtime", "socket.io", "comet", "ajax"]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       , "url": "https://github.com/LearnBoost/socket.io.git"
     }
   , "dependencies": {
-        "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-3.tar.gz"
+        "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-4.tar.gz"
       , "policyfile": "0.0.4"
       , "base64id": "0.1.0"
     }


### PR DESCRIPTION
This PR updates our fork of socket.io to use the latest version of our fork of the socket.io-client library (0.9.17-overleaf-4)
