### PR TITLE
Allow origin function to consider empty origin

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+0.9.19-overleaf-12 / 2025-05-12
+===============================
+
+* Overleaf: Allow `origins` function to handle cases where there is no origin/referer
+
 0.9.19-overleaf-11 / 2025-01-24
 ===============================
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -881,28 +881,27 @@ Manager.prototype.isOriginAllowed = function (origin, request) {
     return true;
   }
 
-  if (origin) {
-    try {
-      var ok = false;
-      if (originsIsFunction) {
-        ok = origins(origin, request);
-      } else {
-        var parts = url.parse(origin);
-        parts.port = parts.port || 80;
-        ok =
-            ~origins.indexOf(parts.hostname + ':' + parts.port) ||
-            ~origins.indexOf(parts.hostname + ':*') ||
-            ~origins.indexOf('*:' + parts.port);
-      }
-      if (!ok) this.log.warn('illegal origin: ' + origin);
-      return ok;
-    } catch (ex) {
+  try {
+    var ok = false;
+    if (originsIsFunction) {
+      ok = origins(origin, request);
+    } else if (origin) {
+      var parts = url.parse(origin);
+      parts.port = parts.port || 80;
+      ok =
+          ~origins.indexOf(parts.hostname + ':' + parts.port) ||
+          ~origins.indexOf(parts.hostname + ':*') ||
+          ~origins.indexOf('*:' + parts.port);
+    }
+    else {
+      this.log.warn('origin missing from handshake, yet required by config');
+    }
+    if (!ok) this.log.warn('illegal origin: ' + origin);
+    return ok;
+  } catch (ex) {
       this.log.warn('error parsing origin');
     }
-  }
-  else {
-    this.log.warn('origin missing from handshake, yet required by config');
-  }
+
   return false;
 };
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -893,9 +893,6 @@ Manager.prototype.isOriginAllowed = function (origin, request) {
           ~origins.indexOf(parts.hostname + ':*') ||
           ~origins.indexOf('*:' + parts.port);
     }
-    else {
-      this.log.warn('origin missing from handshake, yet required by config');
-    }
     if (!ok) this.log.warn('illegal origin: ' + origin);
     return ok;
   } catch (ex) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "socket.io"
-  , "version": "0.9.19-overleaf-11"
+  , "version": "0.9.19-overleaf-12"
   , "description": "Real-time apps made cross-browser & easy with a WebSocket-like API"
   , "homepage": "http://socket.io"
   , "keywords": ["websocket", "socket", "realtime", "socket.io", "comet", "ajax"]


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a new feature

### Current behaviour

Currently when an empty `origin` is passed and no `referer` header is provided then the request is automatically declined. 

### New behaviour

In the situation described above and a function has been provided in the configuration (as `origins`) then the normalised origin will be passed through to the provided function and a decision can be made in the function. Behaviour remains the same in the case that a string is provided.

### Other information (e.g. related issues)

Browsers can choose to not send a `referer` header so it is possible that in a same-origin request we will get neither. 

While websockets generally do not follow the same-origin rules, socket.io has an HTTP request to get an upgrade to wss that will fall under the same-origin rules. 
